### PR TITLE
Fix variable in error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,9 +120,9 @@ function middleware(req, user, fn) {
   var revoked = strict;
   
   var id = user[tokenId];
-  if (!id) return fn(new Error('JWT missing tokenId claim' + tokenId));
+  if (!id) return fn(new Error('JWT missing tokenId claim ' + tokenId));
   var index = user[indexBy];
-  if (!index) return fn(new Error('JWT missing indexBy claim' + tokenId));
+  if (!index) return fn(new Error('JWT missing indexBy claim ' + indexBy));
   
   var key = keyPrefix + id;
   store.get(key, function(err, res) {


### PR DESCRIPTION
The error message variable should be `indexBy`.