### PR TITLE
[fix] expiration of revoked token cannot revive unexpired tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Typically, the server backend will call this function when a particular route is
 
 You can implement your own store by passing `store` object that implements these two functions:
 
- - `get(key, callback)`
+ - `mget(keys, callback)`
  - `set(key, data, lifetime, callback)`
 
 ### Token Payload Considerations

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,7 @@
  * 1. Issued at timestamp(in seconds) is not ideal way to ensure uniqueness and can cause collision
  *    in extreme cases but since it's in the context of a single user it should have no effect.
  * 2. There's no need to store the blacklist data indefinitely since the JWT tokens have expiration built in.
- *    Store expiration is set to match the token expiration. Since we are storing multiple timestamps under
- *    a single key this might result in storing some of the information past expiration date.
+ *    Store expiration is set to match the token expiration.
  */
 
 var debug = require('./debug').log;
@@ -35,7 +34,7 @@ var strict = false;
  *  - revoke: revoke all matched iat timestamps
  *  - purge:  revoke all timestamps older than iat
  */
-var TYPE = exports.TYPE = {
+var TYPE = {
   revoke: 'revoke',
   purge: 'purge'
 };
@@ -63,7 +62,7 @@ exports.configure = function(opts) {
         keyPrefix = opts.store.keyPrefix;
       }
     }
-    else if (typeof opts.store.get === 'function' && typeof opts.store.set === 'function') {
+    else if (typeof opts.store.mget === 'function' && typeof opts.store.set === 'function') {
       store = opts.store;
     }
   }
@@ -117,24 +116,24 @@ exports.__defineSetter__('debug', function(val) {
 });
 
 function middleware(req, user, fn) {
-  var revoked = strict;
-  
+  debug('middleware [user]', user);
+
   var id = user[tokenId];
   if (!id) return fn(new Error('JWT missing tokenId claim ' + tokenId));
   var index = user[indexBy];
   if (!index) return fn(new Error('JWT missing indexBy claim ' + indexBy));
   
-  var key = keyPrefix + id;
-  store.get(key, function(err, res) {
-    if (err) debug('middleware [' + key + '] error:', err);
-    if (!res) return fn(null, revoked);
-    debug('middleware [' + key + ']', res);
-    
-    if (res[TYPE.revoke] && res[TYPE.revoke].indexOf(index) !== -1) revoked = true;
-    else if (res[TYPE.purge] >= user.iat) revoked = true;
-    else revoked = false;
-    
-    fn(null, revoked);
+  var purged = keyPrefix + ':' + id;
+  var revoked = keyPrefix + ':' + id + ':' + index;
+  store.mget([purged, revoked], function(err, res) {
+    if (err) {
+      debug('middleware [' + key + '] error:', err);
+      return fn(null, strict);    
+    }
+    debug('middleware [' + purged + ']', res[purged]);
+    debug('middleware [' + revoked + ']', res[revoked]);
+    if (res[purged] >= user.iat) fn(null, true);
+    else fn(null, res[revoked] === '');
   });
 };
 
@@ -152,29 +151,22 @@ function operation(type, user, lifetime, fn) {
   var id = user[tokenId];
   if (!id) return fn(new Error('JWT missing tokenId claim' + tokenId));
 
-  var key = keyPrefix + id;
-  store.get(key, function(err, res) {
-    if (err) return fn(err);
+  lifetime = lifetime ? lifetime : (user.exp ? user.exp - user.iat : 0);
 
-    var data = res || {};
-    debug('revoke [' + key + '] ' + index, data);
+  debug('operation [' + type + ']', {user: user, lifetime: lifetime});
+
+  if (type === TYPE.purge) {
+
+    var key = keyPrefix + ':' + id;
+    var data = utils.nowInSeconds() - 1;
+
+  } else if (type === TYPE.revoke) {
+
+    var index = user[indexBy];
+    if (!index) return fn(new Error('JWT missing indexBy claim' + tokenId));
+    var key = keyPrefix + ':' + id + ':' + index;
+    var data = '';
     
-    if (type === TYPE.revoke) {
-      var index = user[indexBy];
-      if (!index) return fn(new Error('JWT missing indexBy claim' + tokenId));
-      if (data[TYPE.revoke]) {
-        if (data[TYPE.revoke].indexOf(index) === -1) {
-          data[TYPE.revoke].push(index);
-        }
-      }
-      else data[TYPE.revoke] = [index];
-    }
-
-    if (type === TYPE.purge) {
-      data[TYPE.purge] = utils.nowInSeconds() - 1;
-    }
-
-    lifetime = lifetime ? lifetime : (user.exp ? user.exp - user.iat : 0);
-    store.set(key, data, lifetime, fn);
-  });
+  }
+  store.set(key, data, lifetime, fn);
 };

--- a/lib/store/memcached.js
+++ b/lib/store/memcached.js
@@ -20,8 +20,8 @@ module.exports = function(store) {
     set: function(key, value, lifetime, fn) {
       memcached.set(key, value, lifetime, fn);
     },
-    get: function(key, fn) {
-      memcached.get(key, fn);
+    mget: function(keys, fn) {
+      memcached.getMulti(keys, fn);
     }
   }
 };

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -10,11 +10,20 @@ var cache = {};
 module.exports = function() {
   return {
     set: function(key, value, lifetime, fn) {
-      fn(null, cache[key] = value);
-      if (lifetime) setTimeout(expire.bind(null, key), lifetime * 1000);
+      if (cache[key] && cache[key].timeout) clearTimeout(cache[key].timeout);
+      cache[key] = {
+        data: value,
+        timeout: lifetime ? setTimeout(expire.bind(null, key), lifetime * 1000) : null
+      };
+      fn(null, cache[key].data);
     },
-    get: function(key, fn) {
-      fn(null, cache[key]);
+    mget: function(keys, fn) {
+      var data = {};
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        data[key] = cache[key] ? cache[key].data : null;
+      }
+      fn(null, data);
     }
   };
 };

--- a/lib/store/redis.js
+++ b/lib/store/redis.js
@@ -18,21 +18,13 @@ module.exports = function(store) {
   
   return {
     set: function(key, value, lifetime, fn) {
-      // Serialize array
-      if (value[blacklist.TYPE.revoke]) {
-        value[blacklist.TYPE.revoke] = value[blacklist.TYPE.revoke].toString();
-      } 
-      client.hmset(key, value, fn);
+      client.set(key, value, fn);
       if (lifetime) client.expire(key, lifetime);
     },
-    get: function(key, fn) {
-      client.hgetall(key, function(err, res) {
-        // De-serialize comma separated value, convert to numbers if necessary
-        if (res && res[blacklist.TYPE.revoke]) {
-          res[blacklist.TYPE.revoke] = res[blacklist.TYPE.revoke].split(',').map(function(i) {
-            return (isNaN(i)) ? i : parseInt(i, 10);
-          });
-        }
+    mget: function(keys, fn) {
+      client.mget(keys, function(err, replies) {
+        var res = {};
+        for (var i = 0; i < keys.length; i++) res[keys[i]] = replies[i];
         fn(err, res);
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,255 @@
+{
+  "name": "express-jwt-blacklist",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
+      "requires": {
+        "connection-parse": "0.0.7",
+        "simple-lru-cache": "0.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jackpot": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+      "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
+      "requires": {
+        "retry": "0.6.0"
+      }
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "memcached": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "integrity": "sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=",
+      "requires": {
+        "hashring": "3.2.0",
+        "jackpot": "0.0.6"
+      }
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.1",
+        "redis-parser": "2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
+    "retry": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+      "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc="
+    },
+    "should": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-8.4.0.tgz",
+      "integrity": "sha1-XmCInT5kS73Tl6MM00+tKPz5C8A=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.8.0",
+        "should-format": "0.3.2",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.8.0.tgz",
+      "integrity": "sha1-o/BXMv9FusG3ukEvhAiFaBlkEpk=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.2.tgz",
+      "integrity": "sha1-pZgx4Bot3uFJkRvHFIvlyAMZ4f8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-jwt-blacklist",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "express-jwt plugin for token blacklisting",
   "main": "lib/index.js",
   "scripts": {

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -17,8 +17,13 @@ describe('Blacklist custom store', function() {
   before(function() {
     blacklist.configure({
       store: {
-        get: function(key, callback) {
-          callback(null, cache[key]);
+        mget: function(keys, callback) {
+          var data = {};
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            data[key] = cache[key];
+          };
+          callback(null, data);
         },
         set: function(key, data, lifetime, callback) {
           callback(null, cache[key] = data);


### PR DESCRIPTION
Fixes #8.

Previously, all revoked tokens for a user were stored under a single key in the store, with automatic removal from the store of the entire key based on the lifetime of the most recently revoked token.

Unexpired revoked tokens could be removed from the blacklist if the most recently revoked token had a shorter lifetime, either because the most recently revoked token had an iat earlier than other revoked tokens for that user, or because the most recently revoked token was initially given a shorter lifetime.

This fix stores each revoked token under a separate key and adds tests for the above scenario as well as the new implementation of the purge function, which is implemented as a single-per-user additional key.

This fix introduces a **breaking change** for custom stores. Each blacklist check now requires two keys from the store, a per user check for any purge in addition to the check for revocation of the individual token. In-memory, Redis, and Memcached stores have been modified to batch these operations, with a substitution of a store.mget function rather than store.get; custom stores as well must implement mget instead of get.

This fix uses separate keys for each token rather than the more complex sorted set suggested in #8, both because managing expiration from the store is much simpler, and because the bug in question affects all stores, not just Redis. It is felt that the potential keyspace size increase will be an acceptable less than one order of magnitude considering the presumably short lifetime of each individual key.